### PR TITLE
requirements.txt: Fix requests/urllib3 incompatibility

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -36,7 +36,7 @@ python-coveralls==2.9.1
 python-dateutil==2.8.0
 pytz==2018.9
 PyYAML==5.1.1
-requests==2.21.0
+requests==2.22.0
 Send2Trash==1.5.0
 six==1.12.0
 soupsieve==1.9


### PR DESCRIPTION
ERROR: requests 2.21.0 has requirement urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25.3 which is incompatible.