### PR TITLE
docker: Support running as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
+ARG USER=0:0
 
 # Install required packages and remove the apt packages cache when done.
 
@@ -31,9 +32,6 @@ COPY config/supervisor.conf /etc/supervisor/conf.d/
 COPY app/requirements.txt /code/app/
 RUN pip3 install -r /code/app/requirements.txt
 
-RUN touch /var/log/buildhistorycron.log
-RUN touch /var/log/portinfocron.log
-
 # Setup cron
 COPY config/crons /etc/cron.d/crons
 RUN chmod 0644 /etc/cron.d/crons
@@ -41,5 +39,11 @@ RUN chmod 0644 /etc/cron.d/crons
 # add (the rest of) our code
 COPY . /code/
 
-EXPOSE 80
+RUN touch /var/log/buildhistorycron.log
+RUN touch /var/log/portinfocron.log
+RUN chown -R ${USER} /var/log/buildhistorycron.log /var/log/portinfocron.log /var/log/supervisor /var/log/nginx /var/lib/nginx /code
+RUN chown ${USER} /run
+
+USER ${USER}
+EXPOSE 8080
 CMD ["/usr/bin/supervisord", "-n"]

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -8,7 +8,7 @@ upstream django {
 
 # configuration of the server
 server {
-    listen      80 default_server;
+    listen      8080 default_server;
 
     # the domain name it will serve for
     server_name 127.0.0.1;


### PR DESCRIPTION
For our production deployment, I do not want to run the container with elevated privileges. Instead, allow specifying a user a build argument, add the required chown statements for paths that should be writable during production and switch the nginx port to a port from the unprivileged port range so that non-root users can bind to it.

This allows successfully running the container using the following command line:

```sh
docker run -d \
    --publish 8080:8080 \
    --user=$uid:$gid \
    --env-file=env \
    -v /postgres/socket/dir:/postgres/socket/dir \
    -v /etc/passwd:/etc/passwd:ro \
    --name=macports-webapp macports-webapp
```