### PR TITLE
Do not generate migration files inside the container

### DIFF
--- a/config/setup_app.sh
+++ b/config/setup_app.sh
@@ -2,8 +2,6 @@
 
 cd /code/app
 
-python3 manage.py makemigrations --noinput
-
 python3 manage.py migrate --noinput
 
 python3 manage.py collectstatic --noinput


### PR DESCRIPTION
I just got a realisation that if somehow a migration file is generated inside the container and applied to the database (which is not there in the repository), it may raise conflicts that will require the server administrator's help to fix.

So, the better way would be to supply the migration files when changes are done or whenever required and stop generating any such migrations inside the container. I am not totally sure about this, or do we have any other way to deal with such production environments?