### PR TITLE
Change url structure for port-detail page

### DIFF
--- a/app/ports/urls.py
+++ b/app/ports/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('ajax-call/summary/', views.portdetail_summary, name='port_detail_summary'),
     path('ajax-call/builds/', views.portdetail_build_information, name='port_detail_builds'),
     path('ajax-call/stats/', views.portdetail_stats, name='port_detail_stats'),
+    url(r'^(?P<name>[-a-zA-Z0-9_.]+)/(?P<slug>[a-zA-z]+)/$', views.portdetail, name='port_detail_tabbed'),
     url(r'^(?P<name>[-a-zA-Z0-9_.]+)/$', views.portdetail, name='port_detail'),
 ]

--- a/app/ports/views.py
+++ b/app/ports/views.py
@@ -77,12 +77,12 @@ def variantlist(request, variant):
 
 
 # Views for port-detail page START
-def portdetail(request, name):
+def portdetail(request, name, slug="summary"):
     try:
         req_port = Port.objects.get(name__iexact=name)
         days = request.GET.get('days', 30)
         days_ago = request.GET.get('days_ago', 0)
-        tab = request.GET.get('tab', "summary")
+        tab = str(slug)
         allowed_tabs = ["summary", "builds", "stats", "tickets"]
         if tab not in allowed_tabs:
             return HttpResponse("Invalid tab requested. Expected values: {}".format(allowed_tabs))

--- a/app/static/js/ajax-port-detail.js
+++ b/app/static/js/ajax-port-detail.js
@@ -23,13 +23,14 @@ function ajaxCall(url) {
 // End
 
 function changePageState(e, state) {
+    var port_name = $('#port_name').text();
     $('.active').removeClass("active");
     $(e).addClass("active");
-    history.pushState(null, null, state);
+    history.pushState(null, null, "/port/" + port_name + "/" + state);
 }
 
 function tabClick(e, slug) {
-    changePageState(e, "?tab=" + slug);
+    changePageState(e, slug);
     $('#tickets-box').hide();
     ajaxCall("/port/ajax-call/" + slug);
 }
@@ -63,7 +64,7 @@ function receiveTickets(data, textStatus, jqXHR) {
 }
 
 function showTickets(e) {
-    changePageState(e, "?tab=tickets")
+    changePageState(e, "tickets")
     $('#display-box').html("");
     $('#tickets-box').show();
 }
@@ -124,14 +125,14 @@ function installationStatsAjax(days=$('#days').val(), days_ago=$('#days-ago').va
                 if (currentinstallationStatsAjax != null) {
                     currentinstallationStatsAjax.abort();
                 }
-                history.pushState(null, null, "?tab=stats&days=" + days + "&days_ago=" + days_ago)
+                history.pushState(null, null, "?days=" + days + "&days_ago=" + days_ago)
             },
         dataType: 'html'
     });
 }
 
 function statsClick(e, days, days_ago) {
-    changePageState(e, "?tab=stats");
+    changePageState(e, "stats");
     installationStatsAjax(days, days_ago);
     $('#tickets-box').hide();
 }


### PR DESCRIPTION
This changes the urls of the tabs on the port-detail page:
?tab=summary ->  /info or (just port/<name>)
?tab=builds -> /builds
?tab=stats -> /stats
?tab=tickets -> /tickets
