### PR TITLE
Port Summary: Left align long description and add closed maintainer lock

### DIFF
--- a/app/ports/templates/ports/layout.html
+++ b/app/ports/templates/ports/layout.html
@@ -11,6 +11,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
         integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
         crossorigin="anonymous"></script>
+    <script src="https://kit.fontawesome.com/2178bebbdb.js"></script>
     <script src="{% static 'js/jquery-3.3.1.min.js' %}"></script>
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
     <script src="{% static 'js/ajax-search.js' %}"></script>

--- a/app/ports/templates/ports/port-detail/summary.html
+++ b/app/ports/templates/ports/port-detail/summary.html
@@ -15,7 +15,7 @@
                     <th scope="row">Maintained by:</th>
                     <td>
                         {% if port.closedmaintainer is True %}
-                            <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="This is a closed maintainer port.">
+                            <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Changes of this port require maintainer's approval.">
                                 <i class="fas fa-lock"></i>
                             </button>
                         {% endif %}

--- a/app/ports/templates/ports/port-detail/summary.html
+++ b/app/ports/templates/ports/port-detail/summary.html
@@ -95,7 +95,7 @@
         <div class="col-lg-4">
             <div class="rounded border" style="padding: 8px;">
                 <h6 class="text-center">{{ port.portdir }}</h6>
-                <p class="text-center text-secondary">{{ port.long_description }}</p>
+                <p class="text-secondary">{{ port.long_description }}</p>
             </div>
             <br>
             <div class="rounded border" style="padding: 8px">

--- a/app/ports/templates/ports/port-detail/summary.html
+++ b/app/ports/templates/ports/port-detail/summary.html
@@ -14,6 +14,11 @@
                 <tr>
                     <th scope="row">Maintained by:</th>
                     <td>
+                        {% if port.closedmaintainer is True %}
+                            <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="This is a closed maintainer port.">
+                                <i class="fas fa-lock"></i>
+                            </button>
+                        {% endif %}
                         {% if maintainers.all|length > 0 %}
                         {% for maintainer in maintainers %}
                                 {% if maintainer.github %}
@@ -26,10 +31,6 @@
                             No Maintainers Found
                         {% endif %}
                     </td>
-                </tr>
-                <tr>
-                    <th scope="row">ClosedMaintainer:</th>
-                    <td>{{ port.closedmaintainer }}</td>
                 </tr>
                 <tr>
                     <th scope="row">Variants:</th>

--- a/app/ports/templates/ports/port-detail/summary.html
+++ b/app/ports/templates/ports/port-detail/summary.html
@@ -28,7 +28,7 @@
                                 {% endif %}
                         {% endfor %}
                         {% else %}
-                            No Maintainers Found
+                            (nobody)
                         {% endif %}
                     </td>
                 </tr>

--- a/app/static/js/ajax-port-detail.js
+++ b/app/static/js/ajax-port-detail.js
@@ -136,3 +136,8 @@ function statsClick(e, days, days_ago) {
     $('#tickets-box').hide();
 }
 // Installation Stats AJAX call and filters End
+
+// Mouse over for closed maintainer
+$(document).ready(function() {
+    $("body").tooltip({ selector: '[data-toggle=tooltip]' });
+});


### PR DESCRIPTION
These are some minor frontend improvements.

Here is how the port summary page looks now:
![Screenshot 2019-08-17 at 2 08 35 am](https://user-images.githubusercontent.com/40331563/63196964-2df16b80-c094-11e9-8c8e-f20e55599242.png)
