### PR TITLE
git_update.py: Do not choke on non-port edits

### DIFF
--- a/app/parsing_scripts/git_update.py
+++ b/app/parsing_scripts/git_update.py
@@ -69,7 +69,7 @@ def get_list_of_changed_ports(new_commit=None, old_commit=None):
         changed_paths = subprocess.run([GIT, 'diff', '--name-only', range], stdout=subprocess.PIPE).stdout.decode(
             'utf-8')
         s = io.StringIO(changed_paths)
-        updated_ports_dir = {}
+        updated_ports_dir = set()
         for line in s:
             sections = line.split('/')
             if len(sections) < 2:
@@ -77,7 +77,7 @@ def get_list_of_changed_ports(new_commit=None, old_commit=None):
                 continue
             portdir = sections[0].lower() + '/' + sections[1].lower()
             if portdir not in updated_ports_dir:
-                updated_ports_dir[portdir] = ""
+                updated_ports_dir.add(portdir)
         os.chdir(BASE_DIR)
         print(updated_ports_dir)
         return updated_ports_dir

--- a/app/parsing_scripts/git_update.py
+++ b/app/parsing_scripts/git_update.py
@@ -72,6 +72,9 @@ def get_list_of_changed_ports(new_commit=None, old_commit=None):
         updated_ports_dir = {}
         for line in s:
             sections = line.split('/')
+            if len(sections) < 2:
+                # ignore updates in the root directory
+                continue
             portdir = sections[0].lower() + '/' + sections[1].lower()
             if portdir not in updated_ports_dir:
                 updated_ports_dir[portdir] = ""

--- a/app/ports/tests/test_git_update.py
+++ b/app/ports/tests/test_git_update.py
@@ -15,13 +15,13 @@ class TestGitUpdates(TransactionTestCase):
         ports = git_update.get_list_of_changed_ports("7646d61853154b9dc523e3d0382960aea562e7ab",
                                                      "ee0fc9c4ca59685f33628fc41c6946920869ab71",
                                                      )
-        self.assertEquals(ports, {'devel/ideviceinstaller': '', 'math/openblas': '', 'net/nomad': ''})
+        self.assertEquals(ports, set(['devel/ideviceinstaller', 'math/openblas', 'net/nomad']))
 
     def test_between_new_and_database(self):
         LastPortIndexUpdate.update_or_create_first_object("7646d61853154b9dc523e3d0382960aea562e7ab")
 
         ports = git_update.get_list_of_changed_ports("f3527caa506b1b944f43f47085dd35a8b8e2b050")
-        self.assertEquals(ports, {'net/nomad': '', 'sysutils/terraform': ''})
+        self.assertEquals(ports, set(['net/nomad', 'sysutils/terraform']))
 
     def test_broken_repo(self):
         os.chdir(MACPORTS_PORTS_DIR)
@@ -29,4 +29,4 @@ class TestGitUpdates(TransactionTestCase):
         ports = git_update.get_list_of_changed_ports("7646d61853154b9dc523e3d0382960aea562e7ab",
                                                      "ee0fc9c4ca59685f33628fc41c6946920869ab71",
                                                      )
-        self.assertEquals(ports, {'devel/ideviceinstaller': '', 'math/openblas': '', 'net/nomad': ''})
+        self.assertEquals(ports, set(['devel/ideviceinstaller', 'math/openblas', 'net/nomad']))


### PR DESCRIPTION
Commits such as [e2a40231da0ce1040195081f9e5375c23af07c75][1], which change files in the root directory of the repository caused this code to crash, because `'.travis.yml'.split('/')` does not have two elements. Avoid this by explicitly checking for the number of split elements.

```
Traceback (most recent call last):
  File "/code/app/manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/code/app/ports/management/commands/update-portinfo.py", line 33, in handle
    updated_portdirs = git_update.get_list_of_changed_ports(new_commit, options['old_commit'])
  File "/code/app/parsing_scripts/git_update.py", line 75, in get_list_of_changed_ports
    portdir = sections[0].lower() + '/' + sections[1].lower()
IndexError: list index out of range
```

Additionally, use a set rather than abusing a dict as return value and adjust the tests as necessary.

[1]: https://github.com/macports/macports-ports/commit/e2a40231da0ce1040195081f9e5375c23af07c75