### PR TITLE
Switch to lowercase to spell out 'Today'

### DIFF
--- a/app/ports/templates/ports/port-detail/installation_stats.html
+++ b/app/ports/templates/ports/port-detail/installation_stats.html
@@ -13,7 +13,7 @@
     </select>
     <lable for="days-ago">until</lable>
     <select onchange="installationStatsAjax()" id="days-ago" name="days-ago" class="form-control ml-2">
-        <option value="0" {% if days_ago == 0 %}selected{% endif %}>Today</option>
+        <option value="0" {% if days_ago == 0 %}selected{% endif %}>today</option>
     {% for i in allowed_days|slice:"1:" %}
         <option value="{{ i }}" {% if days_ago == i %}selected{% endif %}>{{ i }} days ago</option>
     {% endfor %}

--- a/app/ports/templates/ports/stats.html
+++ b/app/ports/templates/ports/stats.html
@@ -193,7 +193,7 @@
         </select>
         <lable for="days-ago">until</lable>
         <select onchange="this.form.submit()" id="days_ago" name="days_ago" class="form-control ml-2">
-            <option value="0" {% if days_ago == 0 %}selected{% endif %}>Today</option>
+            <option value="0" {% if days_ago == 0 %}selected{% endif %}>today</option>
             {% for i in allowed_days|slice:"1:" %}
                 <option value="{{ i }}" {% if days_ago == i %}selected{% endif %}>{{ i }} days ago</option>
             {% endfor %}


### PR DESCRIPTION
I still believe that we should be using a single template for duration selection (it could be a template that covers just a tiny part of the website, it doesn't need to actually show the graphs), so that this would reduce to fixing a single file, but I just wanted to fix this in the middle of a sentence.