### PR TITLE
Fix sorting of versions in CLT version chart

### DIFF
--- a/app/ports/templates/ports/port-detail/installation_stats.html
+++ b/app/ports/templates/ports/port-detail/installation_stats.html
@@ -300,7 +300,7 @@
         google.charts.setOnLoadCallback(drawChart);
 
         function drawChart() {
-            {% regroup port_installations_by_os_and_clt_version|dictsort:"submission__clt_version" by submission__clt_version as clt_parent %}
+            {% regroup port_installations_by_os_and_clt_version|sortversion:"submission__clt_version" by submission__clt_version as clt_parent %}
             {% regroup port_installations_by_os_and_clt_version by submission__os_version as os_clt_parent %}
 
             var data = google.visualization.arrayToDataTable([

--- a/app/ports/templates/ports/stats.html
+++ b/app/ports/templates/ports/stats.html
@@ -115,7 +115,7 @@
         google.charts.setOnLoadCallback(drawChart);
 
         function drawChart() {
-            {% regroup os_version_and_clt_version|dictsort:"clt_version" by clt_version as clt_parent %}
+            {% regroup os_version_and_clt_version|sortversion:"clt_version" by clt_version as clt_parent %}
             {% regroup os_version_and_clt_version by os_version as os_clt_parent %}
 
             var data = google.visualization.arrayToDataTable([

--- a/app/ports/templatetags/sort_version.py
+++ b/app/ports/templatetags/sort_version.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 from django import template
 
 register = template.Library()
@@ -5,4 +7,4 @@ register = template.Library()
 
 @register.filter('sortversion')
 def sortversion(distribution, key):
-    return sorted(distribution, key=lambda x: ((0, ) if x[key] == "none" else tuple(int(i) for i in x[key].split("."))))
+    return sorted(distribution, key=lambda x: LooseVersion("0.0.1") if x[key] == "" else LooseVersion("0.0.2") if x[key] == "none" else LooseVersion(x[key]))


### PR DESCRIPTION
I have deployed these changes to: http://ec2-52-34-234-111.us-west-2.compute.amazonaws.com/statistics/

Thank you @mojca for picking this out.