### PR TITLE
Add index to port installations table (/statistics/ports/)

### DIFF
--- a/app/ports/templates/ports/ajax-filters/port_installations_table.html
+++ b/app/ports/templates/ports/ajax-filters/port_installations_table.html
@@ -47,7 +47,10 @@
 {% if installs|length > 0 %}
 {% for port in installs %}
     <div class="row">
-        <div class="col-6 p-2 border-left border-bottom pl-lg-4 pl-3">
+        <div class="col-1 p-2 border-left border-bottom text-right">
+            {{ installs.start_index|add:forloop.counter0 }}
+        </div>
+        <div class="col-5 p-2 border-left border-bottom pl-lg-4 pl-3">
             <a href="{% url 'port_detail' port.port %}">{{ port.port }}</a>
         </div>
         <div class="col-3 p-2 border-left border-bottom text-right">

--- a/app/ports/templates/ports/stats_port_installations.html
+++ b/app/ports/templates/ports/stats_port_installations.html
@@ -37,7 +37,10 @@
     <br>
 <div class="container">
 <div class="row" id="table-header">
-    <div class="col-6 border-left border-top border-bottom text-center">
+    <div class="col-1 border-left border-top border-bottom text-center">
+        <strong>#</strong>
+    </div>
+    <div class="col-5 border-left border-top border-bottom text-center">
         <strong>Port</strong>
         <button id="port" onclick="sort(this)" class="btn btn-sm ml-3">&#9650;</button><button id="-port" onclick="sort(this)" class="btn btn-sm">&#9660;</button>
     </div>


### PR DESCRIPTION
This is a very minor enhancement to the table present on [/statistics/ports/](https://ports.macports.org/statistics/ports/). It adds a new column "S. No." (any suggestions for naming it better?) to the table. It would help rank the ports among the results of various filters.

![Screenshot 2019-08-28 at 7 41 57 PM](https://user-images.githubusercontent.com/40331563/63863462-eb9d2800-c9cb-11e9-8c6d-8aaed6c1d870.png)
