### PR TITLE
Fix errors in detecting deleted ports

### DIFF
--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -276,10 +276,10 @@ class Port(models.Model):
         # ============ END ==============
 
     @classmethod
-    def mark_deleted(cls, dict_of_portdirs):
-        for portdir in dict_of_portdirs:
+    def mark_deleted(cls, dict_of_portdirs_with_ports):
+        for portdir in dict_of_portdirs_with_ports:
             for port in Port.objects.filter(portdir__iexact=portdir).only('portdir', 'name', 'active'):
-                if port.name not in dict_of_portdirs[portdir]:
+                if port.name not in dict_of_portdirs_with_ports[portdir]:
                     port.active = False
                     port.save()
 

--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -279,7 +279,7 @@ class Port(models.Model):
     def mark_deleted(cls, dict_of_portdirs):
         for portdir in dict_of_portdirs:
             for port in Port.objects.filter(portdir__iexact=portdir).only('portdir', 'name', 'active'):
-                if port not in dict_of_portdirs[portdir]:
+                if port.name not in dict_of_portdirs[portdir]:
                     port.active = False
                     port.save()
 

--- a/app/ports/tests/test_update_portinfo.py
+++ b/app/ports/tests/test_update_portinfo.py
@@ -20,7 +20,7 @@ class TestUpdatePortinfo(TransactionTestCase):
     def test_deleted(self):
         Port.mark_deleted({
             'categoryA/port-A1': {
-                'port-A1': True
+                'port-A1'
             }
         })
 

--- a/app/ports/tests/test_update_portinfo.py
+++ b/app/ports/tests/test_update_portinfo.py
@@ -24,10 +24,10 @@ class TestUpdatePortinfo(TransactionTestCase):
             }
         })
 
-        port_status = Port.objects.get(name='port-A1-subport').active
-        for port in Port.objects.all():
-            print(port.name)
-        self.assertEquals(port_status, False)
+        port_status_subport = Port.objects.get(name='port-A1-subport').active
+        port_status_mainport = Port.objects.get(name='port-A1').active
+        self.assertEquals(port_status_mainport, True)
+        self.assertEquals(port_status_subport, False)
 
     def test_added_back(self):
         Port.update([


### PR DESCRIPTION
I still need to perform more tests. And look for any other situations that are being missed, if any. 

Currently, this mechanism to detect deleted ports is totally broken:
- When the main port is removed (portdir is removed), it is not being marked as deleted.
- If one of the subports is deleted, all other subports and parent ports is being marked as deleted.

This PR should fix the above problems.