### PR TITLE
Add test for moved ports

### DIFF
--- a/app/ports/tests/test_update_portinfo.py
+++ b/app/ports/tests/test_update_portinfo.py
@@ -29,7 +29,137 @@ class TestUpdatePortinfo(TransactionTestCase):
         self.assertEquals(port_status_mainport, True)
         self.assertEquals(port_status_subport, False)
 
+    def test_moved(self):
+        Port.update([
+            {
+                "variants": ["universal"],
+                "portdir": "categoryA/port-A1",
+                "depends_fetch": ["bin:port-A4:port-A4"],
+                "description": "This is port A1 of categoryA",
+                "homepage": "http:\/\/portA1.website\/",
+                "epoch": "0",
+                "platforms": "darwin",
+                "name": "port-A2-subport",
+                "depends_lib": ["lib:pq:port-A2", "port:port-A3-diff"],
+                "long_description": "Just a test port written to test something.",
+                "license": "MIT",
+                "maintainers": [{
+                    "email": {
+                        "domain": "email.com",
+                        "name": "user"
+                    },
+                    "github": "user"
+                }],
+                "categories": ["categoryA"],
+                "version": "1.0.0",
+                "revision": "0"
+            },
+            {
+                "variants": ["universal"],
+                "portdir": "categoryA/port-A1",
+                "depends_fetch": ["bin:port-A4:port-A4"],
+                "description": "This is port A1 of categoryA",
+                "homepage": "http:\/\/portA1.website\/",
+                "epoch": "0",
+                "platforms": "darwin",
+                "name": "port-A3-subport",
+                "depends_lib": ["lib:pq:port-A2", "port:port-A3-diff"],
+                "long_description": "Just a test port written to test something.",
+                "license": "MIT",
+                "maintainers": [{
+                    "email": {
+                        "domain": "email.com",
+                        "name": "user"
+                    },
+                    "github": "user"
+                }],
+                "categories": ["categoryA"],
+                "version": "1.0.0",
+                "revision": "0"
+            }
+        ])
+
+        port_status_subport1 = Port.objects.get(name='port-A1-subport').active
+        port_status_subport2 = Port.objects.get(name='port-A2-subport').active
+        port_status_subport3 = Port.objects.get(name='port-A3-subport').active
+        self.assertEquals(port_status_subport1, True)
+        self.assertEquals(port_status_subport2, True)
+        self.assertEquals(port_status_subport3, True)
+
+        # Entire categoryA/port-A1 portdir is removed, but the subports move to other directory
+        # All ports under category/port-A1 would be deleted.
+        Port.mark_deleted({
+            'categoryA/port-A1': {}
+        })
+
+        port_status_subport1 = Port.objects.get(name='port-A1-subport').active
+        port_status_subport2 = Port.objects.get(name='port-A2-subport').active
+        port_status_subport3 = Port.objects.get(name='port-A3-subport').active
+        self.assertEquals(port_status_subport1, False)
+        self.assertEquals(port_status_subport2, False)
+        self.assertEquals(port_status_subport3, False)
+
+        # The moved ports would be found at the new location and will be appended to the list of JSON objects
+        Port.update([
+            {
+                "variants": ["universal"],
+                "portdir": "categoryTemp/newPorts",
+                "depends_fetch": ["bin:port-A4:port-A4"],
+                "description": "This is port A1 of categoryA",
+                "homepage": "http:\/\/portA1.website\/",
+                "epoch": "0",
+                "platforms": "darwin",
+                "name": "port-A2-subport",
+                "depends_lib": ["lib:pq:port-A2", "port:port-A3-diff"],
+                "long_description": "Just a test port written to test something.",
+                "license": "MIT",
+                "maintainers": [{
+                    "email": {
+                        "domain": "email.com",
+                        "name": "user"
+                    },
+                    "github": "user"
+                }],
+                "categories": ["categoryA"],
+                "version": "1.0.0",
+                "revision": "0"
+            },
+            {
+                "variants": ["universal"],
+                "portdir": "categoryTemp/newPorts",
+                "depends_fetch": ["bin:port-A4:port-A4"],
+                "description": "This is port A1 of categoryA",
+                "homepage": "http:\/\/portA1.website\/",
+                "epoch": "0",
+                "platforms": "darwin",
+                "name": "port-A3-subport",
+                "depends_lib": ["lib:pq:port-A2", "port:port-A3-diff"],
+                "long_description": "Just a test port written to test something.",
+                "license": "MIT",
+                "maintainers": [{
+                    "email": {
+                        "domain": "email.com",
+                        "name": "user"
+                    },
+                    "github": "user"
+                }],
+                "categories": ["categoryA"],
+                "version": "1.0.0",
+                "revision": "0"
+            }
+        ])
+
+        port_status_subport2 = Port.objects.get(name='port-A2-subport').active
+        port_status_subport3 = Port.objects.get(name='port-A3-subport').active
+        self.assertEquals(port_status_subport2, True)
+        self.assertEquals(port_status_subport3, True)
+
     def test_added_back(self):
+        Port.mark_deleted({
+            'categoryA/port-A1': {
+                'port-A1'
+            }
+        })
         Port.update([
             {
                 "variants": ["universal"],


### PR DESCRIPTION
This is to support the bug-fix made in https://github.com/macports/macports-webapp/pull/109 .