### PR TITLE
Allow filtering out deleted ports and loop over all ports to identify deleted ports

### DIFF
--- a/app/ports/filters.py
+++ b/app/ports/filters.py
@@ -18,4 +18,4 @@ class PortFilterByMultiple(django_filters.FilterSet):
 
     class Meta:
         model = Port
-        fields = ['categories__name', 'maintainers__name', 'maintainers__github']
+        fields = ['categories__name', 'maintainers__name', 'maintainers__github', 'active']

--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -16,6 +16,11 @@ class PortManager(models.Manager):
         return self.get(name=name)
 
 
+class ActivePortsManager(models.Manager):
+    def get_queryset(self):
+        return super(ActivePortsManager, self).get_queryset().filter(active=True)
+
+
 class Port(models.Model):
     portdir = models.CharField(max_length=100)
     description = models.TextField(default='')
@@ -33,6 +38,7 @@ class Port(models.Model):
     active = models.BooleanField(default=True)
 
     objects = PortManager()
+    get_active = ActivePortsManager()
 
     @classmethod
     def load(cls, data):

--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -276,10 +276,10 @@ class Port(models.Model):
         # ============ END ==============
 
     @classmethod
-    def mark_deleted(cls, dict_of_portdirs_with_ports):
-        for portdir in dict_of_portdirs_with_ports:
-            for port in Port.objects.filter(portdir__iexact=portdir).only('portdir', 'name', 'active'):
-                if port.name not in dict_of_portdirs_with_ports[portdir]:
+    def mark_deleted(cls, all_ports_from_json):
+        with transaction.atomic():
+            for port in Port.objects.all().only('name', 'active'):
+                if port.name.lower() not in all_ports_from_json:
                     port.active = False
                     port.save()
 

--- a/app/ports/templates/ports/ajax-filters/filtered_table.html
+++ b/app/ports/templates/ports/ajax-filters/filtered_table.html
@@ -23,7 +23,7 @@
         </thead>
         {% for port in ports %}
             <tr>
-                <td><a href="{% url 'port_detail' port.port.name %}">{{ port.port.name }}</a></td>
+                <td><a {% if port.active is False %}class="text-danger"{% endif %} href="{% url 'port_detail' port.port.name %}">{{ port.port.name }}</a></td>
                 <td>{{ port.port.version }}</td>
                 <td>{{ port.port.description }}</td>
             </tr>
@@ -41,7 +41,7 @@
         </thead>
         {% for port in ports %}
             <tr>
-                <td><a href="{% url 'port_detail' port.name %}">{{ port.name }}</a></td>
+                <td><a {% if port.active is False %}class="text-danger"{% endif %} href="{% url 'port_detail' port.name %}">{{ port.name }}</a></td>
                 <td>{{ port.version }}</td>
                 <td>{{ port.description }}</td>
             </tr>

--- a/app/ports/templates/ports/index.html
+++ b/app/ports/templates/ports/index.html
@@ -18,6 +18,9 @@
         <div class="form-group">
             <input type="text" class="form-control" id="search" name="search" placeholder="Search Ports">
         </div>
+        <div class="form-group mb-0">
+            <label class="mr-3"><input class="mr-2" id="show-active" onchange="switch_search();" type="checkbox" name="show-active" value="active">Show deleted ports</label>
+        </div>
     </form>
     <br>
     <div class="container" id="main-content">

--- a/app/ports/templates/ports/portdetail.html
+++ b/app/ports/templates/ports/portdetail.html
@@ -13,14 +13,17 @@
 
 {% block content %}
     <br>
-    <form onSubmit="clearTimeout(requestTimer); ajaxCallSearch(); return false">
-            {% csrf_token %}
+    <form onSubmit="clearTimeout(requestTimer); ajaxCallSearch(); return false" class="shadow-sm p-3 rounded">
+        {% csrf_token %}
         <div class="form-group mb-0">
             <label class="radio-inline mr-3"><input class="mr-2" onclick="switch_search()" type="radio" name="search_by" value="name" checked>Search by port-name</label>
-            <label class="radio-inline"><input class="mr-2" onclick="switch_search()" type="radio" name="search_by" value="description">Search by Description</label>
+            <label class="radio-inline"><input class="mr-2" onclick="switch_search()" type="radio" name="search_by" value="description">Search by description</label>
         </div>
         <div class="form-group">
-            <input type="text" class="form-control" id="search" name="search" placeholder="Search All Ports">
+            <input type="text" class="form-control" id="search" name="search" placeholder="Search Ports">
+        </div>
+        <div class="form-group mb-0">
+            <label class="mr-3"><input class="mr-2" id="show-active" onchange="switch_search();" type="checkbox" name="show-active" value="active">Show deleted ports</label>
         </div>
     </form>
     <span style="display: none" id="port_name">{{ req_port.name }}</span>

--- a/app/ports/tests/test_update_portinfo.py
+++ b/app/ports/tests/test_update_portinfo.py
@@ -18,11 +18,7 @@ class TestUpdatePortinfo(TransactionTestCase):
         self.assertEquals(Port.objects.count(), 14)
 
     def test_deleted(self):
-        Port.mark_deleted({
-            'categoryA/port-A1': {
-                'port-A1'
-            }
-        })
+        Port.mark_deleted({'port-a1', 'port-a2', 'port-a3-diff', 'port-a4', 'port-a5', 'port-b1', 'port-c1'})
 
         port_status_subport = Port.objects.get(name='port-A1-subport').active
         port_status_mainport = Port.objects.get(name='port-A1').active
@@ -88,9 +84,7 @@ class TestUpdatePortinfo(TransactionTestCase):
 
         # Entire categoryA/port-A1 portdir is removed, but the subports move to other directory
         # All ports under category/port-A1 would be deleted.
-        Port.mark_deleted({
-            'categoryA/port-A1': {}
-        })
+        Port.mark_deleted({'port-a2', 'port-a3-diff', 'port-a4', 'port-a5', 'port-b1', 'port-c1'})
 
         port_status_subport1 = Port.objects.get(name='port-A1-subport').active
         port_status_subport2 = Port.objects.get(name='port-A2-subport').active
@@ -155,11 +149,8 @@ class TestUpdatePortinfo(TransactionTestCase):
         self.assertEquals(port_status_subport3, True)
 
     def test_added_back(self):
-        Port.mark_deleted({
-            'categoryA/port-A1': {
-                'port-A1'
-            }
-        })
+        Port.mark_deleted({'port-a1', 'port-a2', 'port-a3-diff', 'port-a4', 'port-a5', 'port-b1', 'port-c1'})
+
         Port.update([
             {
                 "variants": ["universal"],

--- a/app/ports/views.py
+++ b/app/ports/views.py
@@ -447,7 +447,15 @@ def maintainer_detail_email(request, name, domain):
 def search(request):
     query = request.GET.get('search_text', '')
     search_by = request.GET.get('search_by', '')
-    ports = PortFilterByMultiple(request.GET, queryset=Port.get_active.all()).qs[:50]
+    name = request.GET.get('name')
+    description = request.GET.get('description')
+    active = True if request.GET.get('active') == 'true' else None
+
+    ports = PortFilterByMultiple({
+        'name': name,
+        'description': description,
+        'active': active
+    }, queryset=Port.objects.all().only('name', 'version', 'description', 'active')).qs[:50]
 
     return render(request, 'ports/ajax-filters/filtered_table.html', {
         'ports': ports,

--- a/app/static/js/ajax-search.js
+++ b/app/static/js/ajax-search.js
@@ -6,7 +6,12 @@ function ajaxCallSearch() {
     data[$("input[name=search_by]:checked").val()] = $('#search').val();
     data['csrfmiddlewaretoken'] = $("input[name=csrfmiddlewaretoken]").val();
     data['search_by'] = $("input[name=search_by]:checked").val();
-    data['search_text'] = $('#search').val()
+    data['search_text'] = $('#search').val();
+    if ($('#show-active').is(':checked')) {
+        data['active'] = '';
+    } else {
+        data['active'] = 'true';
+    }
 
     if ($('#search').val()) {
         $('#filtered_table').show();


### PR DESCRIPTION
I ran the tests on EC2 instance and the process was really fast, finished within 10-15 seconds.

So, I believe we can run it with every update and get rid of the old confusing method to detect deleted ports altogether.