### PR TITLE
Fix 'Most installed version' on port installation stats

### DIFF
--- a/app/ports/templates/ports/port-detail/installation_stats.html
+++ b/app/ports/templates/ports/port-detail/installation_stats.html
@@ -37,7 +37,7 @@
                 </tr>
                 <tr>
                     <th scope="row">Most Installed Version</th>
-                    <td><strong>{{ port_installations_by_port_version.first.version }}</strong> : {{ port_installations_by_port_version.first.num }} user(s)</td>
+                    <td>{% most_installed_version port_installations_by_port_version %}</td>
                 </tr>
             </table>
     <div class="row">

--- a/app/ports/templatetags/utilities.py
+++ b/app/ports/templatetags/utilities.py
@@ -9,3 +9,10 @@ def find_count_for_version(distribution, version):
         if i['version'] == version:
             return i['num']
     return 0
+
+
+@register.simple_tag
+def most_installed_version(distribution):
+    sorted_dict = sorted(distribution, key=lambda x: x['num'], reverse=True)
+    expression = "{} ({} users)".format(sorted_dict[0]['version'], sorted_dict[0]['num'])
+    return expression


### PR DESCRIPTION
Closes: https://github.com/macports/macports-webapp/issues/123