### PR TITLE
Show only active ports by default in port listings

### DIFF
--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -16,6 +16,11 @@ class PortManager(models.Manager):
         return self.get(name=name)
 
 
+class ActivePortsManager(models.Manager):
+    def get_queryset(self):
+        return super(ActivePortsManager, self).get_queryset().filter(active=True)
+
+
 class Port(models.Model):
     portdir = models.CharField(max_length=100)
     description = models.TextField(default='')
@@ -33,6 +38,7 @@ class Port(models.Model):
     active = models.BooleanField(default=True)
 
     objects = PortManager()
+    get_active = ActivePortsManager()
 
     @classmethod
     def load(cls, data):


### PR DESCRIPTION
I am trying to break https://github.com/macports/macports-webapp/pull/122 so that the bug can be fixed without being delayed due to the "Include deleted ports" filter.