### PR TITLE
Fix ports-list styling of maintainer's page for smaller screens

### DIFF
--- a/app/ports/templates/ports/maintainerdetail.html
+++ b/app/ports/templates/ports/maintainerdetail.html
@@ -104,10 +104,10 @@
         {% endif %}
     {% regroup ports|dictsort:'portdir' by portdir as main_ports %}
     <div class="row border-top border-bottom">
-        <div class="col-sm-1 p-2 border-left"></div>
-        <div class="col-sm-3 p-2 border-left"><b>Name</b></div>
-        <div class="col-sm-2 p-2 border-left"><b>Version</b></div>
-        <div class="col-sm-6 p-2 border-left border-right"><b>Description</b></div>
+        <div class="col-1 p-2 border-left"></div>
+        <div class="col-3 p-2 border-left"><b>Name</b></div>
+        <div class="col-2 p-2 border-left"><b>Version</b></div>
+        <div class="col-6 p-2 border-left border-right"><b>Description</b></div>
     </div>
     <div>
         {% for port in main_ports %}
@@ -116,17 +116,17 @@
                 {% with sub_port.portdir|split:"/" as names %}
                     {% if names|index:1 == sub_port.name %}
                     <div class="row border-bottom border-top bg-light">
-                        <div class="col-sm-1 border-left p-0">{% if port.list|length > 1 %}<button class="border-0 bg-transparent" style="width: 100%;height: 100%" data-toggle="collapse" data-target=".{{ names|index:1|cut:'.' }}">&#8680;</button>{% endif %}</div>
-                        <div class="col-sm-3 p-2 border-left"><a href="{% url 'port_detail' sub_port.name %}">{{ sub_port.name }}</a></div>
-                        <div class="col-sm-2 p-2 border-left">{{ sub_port.version }}</div>
-                        <div class="col-sm-6 p-2 border-left border-right">{{ sub_port.description }}</div>
+                        <div class="col-1 border-left p-0">{% if port.list|length > 1 %}<button class="border-0 bg-transparent" style="width: 100%;height: 100%" data-toggle="collapse" data-target=".{{ names|index:1|cut:'.' }}">&#8680;</button>{% endif %}</div>
+                        <div class="col-3 p-2 border-left"><a href="{% url 'port_detail' sub_port.name %}">{{ sub_port.name }}</a></div>
+                        <div class="col-2 p-2 border-left">{{ sub_port.version }}</div>
+                        <div class="col-6 p-2 border-left border-right">{{ sub_port.description }}</div>
                     </div>
                 {% else %}
                     <div class="row collapse show text-secondary {{ names|index:1|cut:'.' }} border-bottom border-top">
-                        <div class="col-sm-1 p-2 border-left"></div>
-                        <div class="col-sm-3 p-2 border-left"><a href="{% url 'port_detail' sub_port.name %}">{{ sub_port.name }}</a></div>
-                        <div class="col-sm-2 p-2 border-left">{{ sub_port.version }}</div>
-                        <div class="col-sm-6 p-2 border-left border-right">{{ sub_port.description }}</div>
+                        <div class="col-1 p-2 border-left"></div>
+                        <div class="col-3 p-2 border-left"><a href="{% url 'port_detail' sub_port.name %}">{{ sub_port.name }}</a></div>
+                        <div class="col-2 p-2 border-left">{{ sub_port.version }}</div>
+                        <div class="col-6 p-2 border-left border-right">{{ sub_port.description }}</div>
                     </div>
                 {% endif %}
                 {% endwith %}


### PR DESCRIPTION
On smaller screens the maintainer's page currently looks like this:

![Screenshot 2019-10-10 at 11 37 14 PM](https://user-images.githubusercontent.com/40331563/66594704-46bf5e80-ebb7-11e9-9d17-345b21a266e0.png)

After applying this commit, it will look like this:

![Screenshot 2019-10-10 at 11 38 02 PM](https://user-images.githubusercontent.com/40331563/66594731-52ab2080-ebb7-11e9-8246-767d279fa86c.png)
