### PR TITLE
Fetch builds from number 0 for new builders

### DIFF
--- a/app/ports/models/buildhistory.py
+++ b/app/ports/models/buildhistory.py
@@ -106,7 +106,9 @@ class BuildHistory(models.Model):
             if build_number_loaded:
                 build_in_database = build_number_loaded[0].build_id + 1
             else:
-                build_in_database = last_build_number - BUILDS_FETCHED_COUNT
+                # build_in_database = last_build_number - BUILDS_FETCHED_COUNT
+                # Temporarily being set to zero to allow fetching all builds for 10.15 builder.
+                build_in_database = 0
 
             for build_number in range(build_in_database, last_build_number):
                 build_data = get_data_from_url(get_url_json(buildername, build_number))


### PR DESCRIPTION
This is a temporary change to allow fetching all builds for 10.15 (to be added- https://github.com/macports/macports-webapp/pull/132). Similar change can be applied to fetch all builds for 10.6-10.8.

Ideally, we need to have a flag which would give the flexibility to allow fetching from beginning or just some previous builds.