### PR TITLE
Capitalised Github to GitHub

### DIFF
--- a/app/ports/templates/ports/maintainerdetail.html
+++ b/app/ports/templates/ports/maintainerdetail.html
@@ -38,7 +38,7 @@
                     <td>{{ maintainer.name }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Github:</th>
+                    <th scope="row">GitHub:</th>
                     {% if maintainer.github %}
                         <td><a target="_blank"
                                href="https://github.com/{{ maintainer.github }}">{{ maintainer.github }}</a></td>

--- a/app/ports/templates/ports/portdetail.html
+++ b/app/ports/templates/ports/portdetail.html
@@ -49,7 +49,7 @@
         <p class="text-secondary">{{ req_port.description }}</p>
         {% if req_port.active is True %}
         <p class="float-right"><a class="btn-warning btn" href="https://github.com/macports/macports-ports/tree/master/{{ req_port.portdir }}/Portfile"
-               target="_blank">View on Github</a><br><br></p>
+               target="_blank">View on GitHub</a><br><br></p>
         {% endif %}
             <h5>Port Health:
                 {% for builder, latest_build in latest_builds.items %}


### PR DESCRIPTION
Fixes #152 
I have found only 2 places where Github is used, corrected them.
