### PR TITLE
Restore the number of builds fetched to last N when no previous builds are available

### DIFF
--- a/app/ports/models/buildhistory.py
+++ b/app/ports/models/buildhistory.py
@@ -106,9 +106,9 @@ class BuildHistory(models.Model):
             if build_number_loaded:
                 build_in_database = build_number_loaded[0].build_id + 1
             else:
-                # build_in_database = last_build_number - BUILDS_FETCHED_COUNT
+                build_in_database = last_build_number - BUILDS_FETCHED_COUNT
                 # Temporarily being set to zero to allow fetching all builds for 10.15 builder.
-                build_in_database = 0
+                # build_in_database = 0
 
             for build_number in range(build_in_database, last_build_number):
                 build_data = get_data_from_url(get_url_json(buildername, build_number))


### PR DESCRIPTION
When the app finds that for a particular builder there are no builds available in the database, it used to fetch only the last N builds, N is defined by `BUILDS_FETCHED_COUNT` in `Macports.config`. But we changed it to fetch all the builds temporarily for the special case of `10.15` builder.

This can now be restored.