### PR TITLE
Convert _ to . while sorting port versions

### DIFF
--- a/app/ports/utilities/sort_by_version.py
+++ b/app/ports/utilities/sort_by_version.py
@@ -2,7 +2,7 @@ from distutils.version import LooseVersion
 
 
 def cleaned_version(version):
-    return version.replace("_", "")
+    return version.replace("_", ".")
 
 
 def sort_list_of_dicts_by_version(lst, key):


### PR DESCRIPTION
This fixes strange version sorting for cases:

`1.18_0` should be ordered below `1.20.1_1`, but removing the underscore was giving opposite results. Instead of removing the underscores, they can be converted to dots (.).