### PR TITLE
Switch to same version sorting algorithm as used by macports-base

### DIFF
--- a/app/ports/tests/test_version_sorting.py
+++ b/app/ports/tests/test_version_sorting.py
@@ -1,0 +1,148 @@
+from django.test import SimpleTestCase
+
+from ports.utilities import sort_by_version
+
+
+class TestVersions(SimpleTestCase):
+    reset_sequences = True
+
+    def test_numeric_dict(self):
+        versions = [
+            {"version": "10.10.1_1"},
+            {"version": "10.10.1_0"},
+            {"version": "10.10"},
+            {"version": "10.10.1"},
+            {"version": "10.10.11"},
+            {"version": "10.9"},
+            {"version": "10.1"},
+            {"version": "10.1.11"},
+            {"version": "10.1.10"},
+            {"version": "10.1.9"},
+            {"version": "9.9.9.9"},
+            {"version": "9.9.9"},
+            {"version": "9.9"},
+            {"version": "9"},
+            {"version": "9.1.0.0"},
+            {"version": "9.1.0.A"},
+            {"version": "9.1.0.a"},
+            {"version": "9.100.1"},
+        ]
+        versions = sort_by_version.sort_list_of_dicts_by_version(versions, "version")
+
+        expected = [
+            {"version": "10.10.11"},
+            {"version": "10.10.1_1"},
+            {"version": "10.10.1_0"},
+            {"version": "10.10.1"},
+            {"version": "10.10"},
+            {"version": "10.9"},
+            {"version": "10.1.11"},
+            {"version": "10.1.10"},
+            {"version": "10.1.9"},
+            {"version": "10.1"},
+            {"version": "9.100.1"},
+            {"version": "9.9.9.9"},
+            {"version": "9.9.9"},
+            {"version": "9.9"},
+            {"version": "9.1.0.0"},
+            {"version": "9.1.0.a"},
+            {"version": "9.1.0.A"},
+            {"version": "9"},
+        ]
+
+        self.assertEquals(versions, expected)
+
+    def test_alphanumeric_dict(self):
+        versions = [
+            {"version": "10.10.a"},
+            {"version": "10.10.a1"},
+            {"version": "10.10.a2"},
+            {"version": "10.10.a12"},
+            {"version": "10.a.1"},
+            {"version": "10.aa.1"},
+            {"version": "10.ab.1"},
+            {"version": "10.b.1"},
+            {"version": "10.a"},
+            {"version": "10.b"},
+            {"version": "10.1.a"},
+            {"version": "10.1-a_0"},
+            {"version": "10.1-c_0"},
+            {"version": "10.+-=!ABC_0"},
+            {"version": "AAAAAA"},
+            {"version": "AAA.AAA"},
+            {"version": "AAA-A-A"},
+            {"version": "AAA-A+B"},
+        ]
+        versions = sort_by_version.sort_list_of_dicts_by_version(versions, "version")
+
+        expected = [
+            {"version": "10.10.a2"},
+            {"version": "10.10.a12"},
+            {"version": "10.10.a1"},
+            {"version": "10.10.a"},
+            {"version": "10.1-c_0"},
+            {"version": "10.1-a_0"},
+            {"version": "10.1.a"},
+            {"version": "10.b.1"},
+            {"version": "10.b"},
+            {"version": "10.ab.1"},
+            {"version": "10.aa.1"},
+            {"version": "10.a.1"},
+            {"version": "10.a"},
+            {"version": "10.+-=!ABC_0"},
+            {"version": "AAAAAA"},
+            {"version": "AAA.AAA"},
+            {"version": "AAA-A+B"},
+            {"version": "AAA-A-A"},
+        ]
+        self.assertEquals(versions, expected)
+
+    def test_version_list(self):
+        versions = [
+            "10.10.a",
+            "10.1_0.a",
+            "10.10.a1",
+            "10.10.a2",
+            "10.10.a12",
+            "10.a.a",
+            "10.aa.1",
+            "10.ab.1",
+            "10.b.1",
+            "10.a",
+            "10.b",
+            "10.1_0.a",
+            "10.1.a",
+            "10.1-a_0",
+            "10.1-c_0",
+            "10.+-=!ABC_0",
+            "AAAAAA",
+            "AAA.AAA",
+            "AAA-A-A",
+            "AAA-A+B"
+        ]
+        versions = sort_by_version.sort_list_by_version(versions)
+
+        expected = [
+            "10.10.a2",
+            "10.10.a12",
+            "10.10.a1",
+            "10.10.a",
+            "10.1_0.a",
+            "10.1_0.a",
+            "10.1-c_0",
+            "10.1-a_0",
+            "10.1.a",
+            "10.b.1",
+            "10.b",
+            "10.ab.1",
+            "10.aa.1",
+            "10.a.a",
+            "10.a",
+            "10.+-=!ABC_0",
+            "AAAAAA",
+            "AAA.AAA",
+            "AAA-A+B",
+            "AAA-A-A",
+        ]
+
+        self.assertEquals(versions, expected)

--- a/app/ports/utilities/sort_by_version.py
+++ b/app/ports/utilities/sort_by_version.py
@@ -1,13 +1,59 @@
-from distutils.version import LooseVersion
+import re
+from functools import cmp_to_key
 
 
-def cleaned_version(version):
-    return version.replace("_", ".").replace("-", ".")
+# Tries to apply the same version sorting algorithm as used by macports-base
+# https://github.com/macports/macports-base/blob/master/src/pextlib1.0/vercomp.c
+def version_compare(version1, version2):
+    # Split on all non-alphanumeric characters and delete any empty ('') elements
+    # that might occur due to consecutive non-alphanumerics
+    version1_segments = list(filter(None, re.split('[^a-zA-Z0-9]', version1)))
+    version2_segments = list(filter(None, re.split('[^a-zA-Z0-9]', version2)))
+
+    version1_len = len(version1_segments)
+    version2_len = len(version2_segments)
+
+    # Now traverse the two lists and compare segments at each index
+    i = 0
+    while i < version1_len and i < version2_len:
+        s1 = version1_segments[i]
+        s2 = version2_segments[i]
+
+        # If version1's segment is a numeric segment and version2's segment
+        # is non-numeric, consider version1 to be a newer version
+        if s1.isnumeric() and (not s2.isnumeric()):
+            return -1
+
+        # If the segments are of different types, consider version2 be newer
+        if (s1.isnumeric() and s2.isalpha()) or (s1.isalpha() and s2.isnumeric()):
+            return 1
+
+        # The segments are either both numeric or both alphabetical
+        # If they are numeric, convert to integers and compare
+        if s1.isnumeric() and s2.isnumeric():
+            if int(s1) > int(s2):
+                return -1
+            elif int(s1) < int(s2):
+                return 1
+        else:
+            if s1 > s2:
+                return -1
+            elif s1 < s2:
+                return 1
+
+        i += 1
+
+    # If the length of both the versions is same, means they are equal
+    if i == version1_len and i == version2_len:
+        return 0
+
+    # Otherwise, the version with a greater length is newer
+    return 1 if version2_len > version1_len else -1
 
 
 def sort_list_of_dicts_by_version(lst, key):
-    return sorted(lst, key=lambda x: LooseVersion(cleaned_version(x[key])), reverse=True)
+    return sorted(lst, key=cmp_to_key(lambda x, y: version_compare(x[key], y[key])))
 
 
 def sort_list_by_version(lst):
-    return sorted(lst, key=lambda x: LooseVersion(cleaned_version(x)), reverse=True)
+    return sorted(lst, key=cmp_to_key(version_compare))


### PR DESCRIPTION
fixes: https://github.com/macports/macports-webapp/issues/216

Python's `LooseVersion` started to fail with a `TypeError`, so we need to switch to a different version sorting algorithm.

I have tried to implement the same algorithm as from [here](https://github.com/macports/macports-base/blob/master/src/pextlib1.0/vercomp.c) which seems to be the RPM version sorting algorithm.

Also, added a few test cases