### PR TITLE
Stats: Fix users by month chart not displaying all months

### DIFF
--- a/app/ports/views.py
+++ b/app/ports/views.py
@@ -284,19 +284,21 @@ def stats(request):
 
     end_date = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=days_ago)
     start_date = end_date - datetime.timedelta(days=days)
+    today_day = datetime.datetime.now().day
+    last_12_months = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=int(today_day) + 365)
 
     current_week = datetime.datetime.today().isocalendar()[1]
-    all_submissions = Submission.objects.all()
+    all_submissions = Submission.objects.all().only('id')
     total_unique_users = all_submissions.distinct('user').count()
     current_week_unique = all_submissions.filter(timestamp__week=current_week).distinct('user').count()
     last_week_unique = all_submissions.filter(timestamp__week=current_week - 1).distinct('user').count()
 
     # Number of unique users vs month
-    users_by_month = Submission.objects.annotate(month=TruncMonth('timestamp')).values('month').annotate(num=Count('user_id', distinct=True))[:12]
+    users_by_month = Submission.objects.only('id').filter(timestamp__gte=last_12_months).annotate(month=TruncMonth('timestamp')).values('month').annotate(num=Count('user_id', distinct=True))
 
     # System Stats for Current Users
-    submissions_last_x_days = Submission.objects.filter(timestamp__range=[start_date, end_date]).order_by('user', '-timestamp').distinct('user')
-    submissions_unique = Submission.objects.filter(id__in=Subquery(submissions_last_x_days.values('id')))
+    submissions_last_x_days = Submission.objects.only('id').filter(timestamp__range=[start_date, end_date]).order_by('user', '-timestamp').distinct('user')
+    submissions_unique = Submission.objects.only('id').filter(id__in=Subquery(submissions_last_x_days.values('id')))
     macports_version = sort_list_of_dicts_by_version(list(submissions_unique.values('macports_version').annotate(num=Count('macports_version'))), 'macports_version')
     os_version_and_clt_version = sort_list_of_dicts_by_version(list(submissions_unique.values('clt_version', 'os_version').annotate(num=Count('user_id', distinct=True))), 'os_version')
     os_version_build_arch_and_stdlib = sort_list_of_dicts_by_version(list(submissions_unique.values('os_version', 'build_arch', 'cxx_stdlib').annotate(num=Count('user_id', distinct=True))), 'os_version')


### PR DESCRIPTION
The Users vs Month chart on [stats](https://ports.macports.org/statistics/) page uses slicing to get the last 12 months, which is incorrect because that slicing is actually taking up the first 12 months since the inception and not the last

A better alternative to slicing is to filter the submissions by last 12 months.