### PR TITLE
Support parsing of license list

### DIFF
--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -161,6 +161,18 @@ class Port(models.Model):
 
     @classmethod
     def update(cls, data):
+        def parse_license(license_object):
+            if isinstance(license_object, str):
+                return license_object
+
+            # format of license : license_object = ["MIT",["PSF","ZPL"],["Apache-2","BSD"]]
+            # required output: MIT and (PSF or ZPL) and (Apache-2 or BSD)
+            # We loop over each list element and join parent elements with "and".
+            # If child elements is a list, we join its internal elements using "or"
+
+            license_string = " and ".join(["({})".format(" or ".join(x)) if isinstance(x, list) else x for x in license_object])
+            return license_string
+
         def open_portindex_json(path):
             with open(path, "r", encoding='utf-8') as file:
                 data = json.load(file)
@@ -180,7 +192,7 @@ class Port(models.Model):
                 port_object.long_description = port.get('long_description', '')
                 port_object.revision = port.get('revision', 0)
                 port_object.closedmaintainer = port.get('closedmaintainer', False)
-                port_object.license = port.get('license', '')
+                port_object.license = parse_license(port.get('license', ''))
                 port_object.replaced_by = port.get('replaced_by')
                 port_object.active = True
                 port_object.save()


### PR DESCRIPTION
Closes: https://github.com/macports/macports-webapp/issues/234 https://github.com/macports/macports-webapp/issues/44

This is needed to support improvements done to portindex2json: https://github.com/macports/macports-contrib/pull/6 . Till now, the license field has been a string in portindex.json which was wrong. The `license` in Portfiles is a TCL list, and should also be a list in JSON.

This PR supports the parsing of license list from portindex.json instead of just a string.