### PR TITLE
Port.update(): Improve MultipleObjectsReturned err msg

### DIFF
--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -264,6 +264,12 @@ class Port(models.Model):
                                     print("Failed to append {} as a dependency to {}. Not Found.".format(
                                         depends.rsplit(':', 1)[-1],
                                         port['name']))
+                                except MultipleObjectsReturned as e:
+                                    print("Could not append {} as a dependency to {}, because the depspec does"
+                                          " not uniquely identify a port".format(
+                                        depends,
+                                        port['name']))
+                                    raise e
                             obj.save()
                             obj.dependencies.add(*dependencies)
 


### PR DESCRIPTION
The cronjob is currently failing with

```
ERROR OUTPUT:
Traceback (most recent call last):
  File "/code/app/manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/code/app/ports/management/commands/update-portinfo.py", line 55, in handle
    Port.update(ports_to_be_updated_json)
  File "/code/app/ports/models/port.py", line 292, in update
    run_updates(data)
  File "/code/app/ports/models/port.py", line 277, in run_updates
    full_update_dependencies(ports)
  File "/code/app/ports/models/port.py", line 262, in full_update_dependencies
    dependencies.append(Port.objects.get(name__iexact=depends.rsplit(':', 1)[-1]))
  File "/usr/local/lib/python3.6/dist-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django/db/models/query.py", line 412, in get
    (self.model._meta.object_name, num)
ports.models.port.MultipleObjectsReturned: get() returned more than one Port -- it returned 2!
```

Improve the error message printed when this exception occurs to find out why this seems to be a problem. Note that this started showing up on August 31st, shortly after the django update to 2.2.13 was merged in ecfcbb7da3aa79dce124f3e5f2b9bfc73e341db3.