### PR TITLE
Port.update(): Fix exception name

### DIFF
--- a/app/ports/models/port.py
+++ b/app/ports/models/port.py
@@ -264,7 +264,7 @@ class Port(models.Model):
                                     print("Failed to append {} as a dependency to {}. Not Found.".format(
                                         depends.rsplit(':', 1)[-1],
                                         port['name']))
-                                except MultipleObjectsReturned as e:
+                                except Port.MultipleObjectsReturned as e:
                                     print("Could not append {} as a dependency to {}, because the depspec does"
                                           " not uniquely identify a port".format(
                                         depends,


### PR DESCRIPTION
`MultipleObjectsReturned` does not exist, but `Port.MultipleObjectsReturned` does. Since this could happen again the next time somebody case-renames a port, let's keep the code in to avoid additional debugging the next time.