### PR TITLE
Change port detail page title to include "MacOS"

### DIFF
--- a/app/ports/templates/ports/portdetail.html
+++ b/app/ports/templates/ports/portdetail.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 {% endblock %}
 
-{% block title %}Install {{ req_port.name }} Port on MacOS -  |{% endblock %}
+{% block title %}Install {{ req_port.name }} Port on macOS -  |{% endblock %}
 
 {% block content %}
     <br>

--- a/app/ports/templates/ports/portdetail.html
+++ b/app/ports/templates/ports/portdetail.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 {% endblock %}
 
-{% block title %}{{ req_port.name }}- Port |{% endblock %}
+{% block title %}Install {{ req_port.name }} Port on MacOS -  |{% endblock %}
 
 {% block content %}
     <br>


### PR DESCRIPTION
The page do not mention MacOS. This could improve SEO a bit.