### PR TITLE
Remove "ports" from page title

### DIFF
--- a/app/ports/templates/ports/portdetail.html
+++ b/app/ports/templates/ports/portdetail.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 {% endblock %}
 
-{% block title %}Install {{ req_port.name }} Port on macOS -  |{% endblock %}
+{% block title %}Install {{ req_port.name }} on macOS |{% endblock %}
 
 {% block content %}
     <br>


### PR DESCRIPTION
https://github.com/macports/macports-webapp/pull/260  Follow-up