### PR TITLE
Add ports-old.macports.org to ALLOWED_HOSTS

### DIFF
--- a/app/MacPorts/settings.py
+++ b/app/MacPorts/settings.py
@@ -29,7 +29,8 @@ DEBUG = False
 USE_X_FORWARDED_HOST = True
 
 ALLOWED_HOSTS = [
-    'ports.macports.org'
+    'ports.macports.org',
+    'ports-old.macports.org',
 ]
 
 


### PR DESCRIPTION
This change should allow running the old site under https://ports-old.macports.org for a little while after switching to the new site.