### PR TITLE
Skip 0th and 12th month from monthly stats

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -39,6 +39,7 @@ jsonfield==3.1.0
 lazy-object-proxy==1.4.0
 MarkupSafe==1.1.1
 mccabe==0.6.1
+MonthDelta==0.9.1
 oauthlib==3.1.0
 packaging==20.4
 pluggy==0.13.1

--- a/app/stats/serializers.py
+++ b/app/stats/serializers.py
@@ -9,6 +9,7 @@ from stats.models import Submission
 from stats.utilities.sort_by_version import sort_list_of_dicts_by_version
 from stats.validators import ALLOWED_DAYS_FOR_STATS as ALLOWED_DAYS
 from stats.validators import ALLOWED_PROPERTIES, ALLOWED_GENERAL_PROPERTIES
+from stats.utilities import dates
 
 
 class PortStatisticsSerializer(serializers.Serializer):
@@ -120,11 +121,10 @@ class PortMonthlyInstallationsSerializer(serializers.Serializer):
         is_valid = self.validate_context()
         if not is_valid:
             return PortInstallation.objects.none()
-        today_day = datetime.datetime.now().day
-        last_12_months = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=int(today_day) + 365)
+
         result = PortInstallation.objects \
             .only('id') \
-            .filter(port__iexact=self.port_name, submission__timestamp__gte=last_12_months) \
+            .filter(port__iexact=self.port_name, submission__timestamp__gte=dates.get_first_day_of_month_x_months_ago(12)) \
             .annotate(datetime=TruncMonth('submission__timestamp')) \
             .order_by('datetime') \
             .annotate(

--- a/app/stats/utilities/dates.py
+++ b/app/stats/utilities/dates.py
@@ -1,0 +1,6 @@
+from datetime import datetime, timezone
+from monthdelta import monthdelta
+
+def get_first_day_of_month_x_months_ago(x = 12):
+    return (datetime.now(tz=timezone.utc) - monthdelta(x)) \
+            .replace(day=1, hour=0, minute=0, second=0)


### PR DESCRIPTION
Since, we collect stats many times in a month, the result of 0th and 12th month show incomplete data. This happens because we are still collecting data for the 12th month (which is actually the ongoing month) and the 0th month comes into picture due to how we calculate `last 12 months`.  0th month shows data for just last 1 or 2 days of the month, which we anyways do not intend to show in the charts.

<img width="711" alt="Screenshot 2021-07-17 at 2 11 23 PM" src="https://user-images.githubusercontent.com/40331563/126031629-bc2510de-cd2f-4670-ba35-c9a8a92a9047.png">
