### PR TITLE
Do not show "Total submissions" on stats page

### DIFF
--- a/app/stats/templates/stats/stats.html
+++ b/app/stats/templates/stats/stats.html
@@ -27,10 +27,10 @@
             <br>
             <table class="table table-striped">
                 <tbody>
-                <tr>
+                <!-- <tr>
                     <th scope="row">Total submissions:</th>
                     <td class="text-right">{{ total_submissions }}</td>
-                </tr>
+                </tr> -->
                 <tr>
                     <th scope="row">Total unique users:</th>
                     <td class="text-right">{{ unique_users }}</td>


### PR DESCRIPTION
I have setup stats data older than 18 months to be purged. So "total submissions" will not provide accurate information. I also feel that this wasn't useful anyways.

<img width="479" alt="Screenshot 2021-07-17 at 5 53 05 PM" src="https://user-images.githubusercontent.com/40331563/126036721-3a955a67-b8e6-4ce2-841e-5bf8c0915260.png">
