### PR TITLE
Add "report an issue" button to port pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ target/
 *.pyc
 __pycache__/
 local_settings.py
+staticfiles
 
 .env
 db.sqlite3

--- a/app/port/templates/port/includes/port-tabs.html
+++ b/app/port/templates/port/includes/port-tabs.html
@@ -12,13 +12,16 @@
         <a href="#" data-toggle="modal" data-target="#tickets-modal" class="nav-link text-dark">Trac Tickets <span id="tickets-count" class="badge badge-light border border-secondary"></span></a>
     </li>
     <li class="nav-item ml-auto">
+        <a target="_blank" href="https://trac.macports.org/newticket?port={{ port.name }}" class="nav-link text-dark f14 py-1 border-0">Report an Issue with this port</a>
+    </li>
+    <li class="nav-item">
         <a href="{% url 'port-detail' port.name %}" class="nav-link text-dark f14 py-1 border-0">API</a>
     </li>
     {% if request.path == "/port/"|add:port.name|add:"/details/" %}
     <li class="nav-item">
         <a href="{% url 'default_port_page_toggle' port.name %}" class="nav-link text-muted border-0 f14 py-1">
-            {% if is_default %}Remove default
-            {% else %}Make default
+            {% if is_default %}Never skip to Details page
+            {% else %}Always skip to Details page
             {% endif %}
         </a>
     </li>

--- a/app/port/templates/port/port_basic.html
+++ b/app/port/templates/port/port_basic.html
@@ -29,6 +29,9 @@
                     <br>
                 <button class="btn btn-link text-secondary" data-toggle="modal" data-target="#instructions">More instructions
                 </button>
+                <button class="btn text-secondary" data-toggle="modal" data-target="#report-an-issue">
+                    <i class="text-secondary fas fa-exclamation-circle"></i> Report an issue with this port
+                </button>
                 <div class="modal fade" id="instructions" tabindex="-1" role="dialog" aria-labelledby="insLabel"
                      aria-hidden="true">
                     <div class="modal-dialog modal-lg" role="document">
@@ -63,6 +66,29 @@
                                         </div>
                                     </li>
                                 </ul>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal fade" id="report-an-issue" tabindex="-1" role="dialog" aria-labelledby="insLabel" aria-hidden="true">
+                    <div class="modal-dialog modal-lg" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="insLabel">Reporting an issue on MacPorts Trac</h5>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body text-left">
+                                The MacPorts Project uses a system called Trac to file tickets to report bugs and enhancement requests. 
+                                Though anyone may search Trac for tickets, <strong>you must have a GitHub account</strong> in order to login to Trac to create tickets.<br><br>
+                                <div class="text-center mt-4">
+                                        <a target="_blank" href="https://trac.macports.org/newticket?port={{ port.name }}" class="btn btn-primary">Report an Issue on MacPorts Trac</a>
+                                        (GitHub login required)
+                                    </div>
                             </div>
                             <div class="modal-footer">
                                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>


### PR DESCRIPTION
See https://github.com/macports/macports-webapp/issues/310

We have been receiving few port-related issues on `macports-webapp` GitHub repo. These buttons might help in directing users to the correct place for reporting issues with ports.

Clicking on the link takes you to `https://trac.macports.org/newticket?port=<port-name>`

![Screenshot 2022-01-15 at 2 37 58 PM](https://user-images.githubusercontent.com/40331563/149616460-05dfc475-adcb-416b-8d63-2475e758126b.png)
![Screenshot 2022-01-15 at 2 38 38 PM](https://user-images.githubusercontent.com/40331563/149616462-93a73a08-08fe-4b84-94df-cbd8b2f75b99.png)

