### PR TITLE
Hide port long description with full stop

### DIFF
--- a/app/port/templates/port/includes/full-description-collapsible.html
+++ b/app/port/templates/port/includes/full-description-collapsible.html
@@ -1,4 +1,4 @@
-{% if d == ld %}
+{% if d == ld or d|add:"." == ld %}
     <br>
 {% else %}
     <p class="my-0 pt-0" id="long_description">{{ ld }}</p>


### PR DESCRIPTION
Currently, if `description == long_description`, the long description is hidden.

![image](https://user-images.githubusercontent.com/12570877/149932450-771fe8a6-54e9-4e56-b726-f1d398a0f8d5.png)

It's quite common in some ports for the long description to simply be `{*}${description}.` (note the full stop), in which case the long description is shown.

![image](https://user-images.githubusercontent.com/12570877/149931980-b772c62f-744f-404b-9fe5-44a5ca5d7432.png)

This very simple PR aims to change this behaviour to hide the long description in both cases.
