### PR TITLE
added tooltip to index on macports stats

### DIFF
--- a/app/stats/templates/stats/stats.html
+++ b/app/stats/templates/stats/stats.html
@@ -131,6 +131,10 @@
 						display: false,
 						text: 'MacPorts Version'
 					},
+                    tooltips: {
+						mode: 'index',
+						intersect: false
+					},
 					responsive: true
 				}
         });


### PR DESCRIPTION
Signed-off-by: Dhruv-Sachdev1313 <dhruvhsachdev@gmail.com>

trying to fix - Use index tooltip on the main statistics page #306 


Since I am having difficulty in setting up the project locally (SOLR is giving me issues!), I have not tested it locally yet.
This was a very small addition, so I thought it would not break anything. Thus this PR 

I am looking on the internet actively to fix the errors while setting up this project, maybe if I figure it out today, I can test it quickly and let you know!!