### PR TITLE
Include port version and revision in build history

### DIFF
--- a/app/buildhistory/serializers.py
+++ b/app/buildhistory/serializers.py
@@ -14,7 +14,7 @@ class BuildHistorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = BuildHistory
-        fields = ('port_name', 'builder_name', 'build_id', 'status', 'time_start', 'time_elapsed', 'watcher_id')
+        fields = ('port_name', 'port_version', 'port_revision', 'builder_name', 'build_id', 'status', 'time_start', 'time_elapsed', 'watcher_id')
 
 
 class FilesSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
I've recently launched a [service](https://github.com/AMDmi3/wiyci) which aggregates package build logs and parses warnings and other issues from these, hopefully extending upstream awareness and encouraging fix contributions, currently hosted at https://wiyci.repology.org. I'd like to add macports as another build logs source, for that I need to be able to get to a build log for a given package/version/revision. I plan to do it using build history API (complete algorithm described in the [issue](https://github.com/AMDmi3/wiyci/issues/31) under Macports section), however the history currently lacks version and revision fields so it's not possible to pick a build for the right version. To fix that, I propose to add these fields. Or maybe there's a simpler solution I have missed?

For the record, the service is designed not to generate excess load on the server, limiting request rate by 1 request in 3 seconds by default. If macports support is added it'll have to catch up by downloading logs for all covered projects (~10k as of now, but I hope to grow it few times) which should be 10k * number of covered macos versions (which can be limited with only the latest version if so desired), after which it'll only download logs for updated versions, which, judging by already supported repositories, is less than 100 per day.